### PR TITLE
fix error on linux build due to windows libraries included in error

### DIFF
--- a/netcoin-qt.pro
+++ b/netcoin-qt.pro
@@ -348,11 +348,12 @@ macx:TARGET = "Netcoin-Qt"
 # Set libraries and includes at end, to use platform-defined defaults if not overridden
 INCLUDEPATH += $$BOOST_INCLUDE_PATH $$BDB_INCLUDE_PATH $$OPENSSL_INCLUDE_PATH $$QRENCODE_INCLUDE_PATH
 LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) $$join(QRENCODE_LIB_PATH,,-L,)
-LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX -loleaut32
+LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX 
+windows:LIBS += -loleaut32
 # -lgdi32 has to happen after -lcrypto (see  #681)
 windows:LIBS += -lole32 -luuid -lgdi32 
-LIBS += E:\MinGW\lib\libws2_32.a
-LIBS += E:\MinGW\lib\liboleaut32.a
+windows:LIBS += E:\MinGW\lib\libws2_32.a
+windows:LIBS += E:\MinGW\lib\liboleaut32.a
 LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
 
 contains(RELEASE, 1) {


### PR DESCRIPTION
To build netcoin-qt without errors on linux by running qmake followed by make
